### PR TITLE
Import util submodule directly

### DIFF
--- a/util.py
+++ b/util.py
@@ -2,7 +2,7 @@ import sys
 import re
 
 def check_gdb():
-    import importlib
+    import importlib.util
     return importlib.util.find_spec("gdb") is not None
 
 verbose = False


### PR DESCRIPTION
Causes a bug on some systems otherwise:
https://stackoverflow.com/questions/39660934/error-when-using-importlib-util-to-check-for-library