### PR TITLE
Support parsing libwayland "discarded" message prefix

### DIFF
--- a/backends/libwayland_debug_output/parse.py
+++ b/backends/libwayland_debug_output/parse.py
@@ -32,9 +32,10 @@ class WlPatterns:
         timestamp_regex = r'\[\s*(?P<timestamp>\d+[\.,]\d+)\s*\]'
         conn_re = r'( \<(?P<conn>\w+)\>)?'
         queue_re = r'( {.*})?'
+        discarded_re = r'(?P<discarded> discarded)?'
         message_regex = r'(?P<type>\w+)[@#](?P<id>\d+)\.(?P<message>\w+)\((?P<args>.*)\)$'
-        self.out_msg_re = re.compile(timestamp_regex + queue_re + conn_re + '  -> ' + message_regex)
-        self.in_msg_re = re.compile(timestamp_regex + queue_re + conn_re + ' ' + message_regex)
+        self.out_msg_re = re.compile(timestamp_regex + queue_re + conn_re + discarded_re + '  -> ' + message_regex)
+        self.in_msg_re = re.compile(timestamp_regex + queue_re + conn_re + discarded_re + ' ' + message_regex)
 
     @staticmethod
     def lazy_get_instance() -> 'WlPatterns':
@@ -110,8 +111,9 @@ def message(raw: str) -> Tuple[str, wl.Message]:
     obj_id = int(match.group('id'))
     message_name = match.group('message')
     message_args_str = match.group('args')
+    discarded = match.group('discarded') is not None
     message_args = argument_list(p, message_args_str)
-    return conn_id, wl.Message(abs_timestamp, wl.UnresolvedObject(obj_id, type_name), sent, message_name, message_args)
+    return conn_id, wl.Message(abs_timestamp, wl.UnresolvedObject(obj_id, type_name), sent, message_name, message_args, discarded)
 
 class Parser:
     def __init__(self, out: Output, sink: ConnectionIDSink):

--- a/core/wl/message.py
+++ b/core/wl/message.py
@@ -10,7 +10,7 @@ class Message:
     # TODO: figure out a way to remove global time offset
     base_time = None
 
-    def __init__(self, abs_time: float, obj: ObjectBase, sent: bool, name: str, args: Tuple[Arg.Base, ...]) -> None:
+    def __init__(self, abs_time: float, obj: ObjectBase, sent: bool, name: str, args: Tuple[Arg.Base, ...], discarded: bool = False) -> None:
         if Message.base_time is None:
             Message.base_time = abs_time
         self.timestamp = abs_time - Message.base_time
@@ -19,6 +19,7 @@ class Message:
         self.name = name
         self.args = args
         self.destroyed_obj: Optional[ObjectBase] = None
+        self.discarded = discarded
 
     def resolve(self, conn: Connection) -> None:
         if not self.obj.resolved():
@@ -46,6 +47,7 @@ class Message:
         return tuple(result)
 
     def __str__(self) -> str:
+        discarded_str = color(symbol_color, '(discarded) ') if self.discarded else ''
         destroyed = ''
         if self.destroyed_obj:
             destroyed = (
@@ -56,6 +58,7 @@ class Message:
             if lifespan is not None:
                 destroyed += color(timestamp_color, ' after {:0.4f}s'.format(lifespan))
         return (
+            discarded_str +
             (color(symbol_color, '→ ') if self.sent else '') +
             str(self.obj) +
             color(message_color, '.' + self.name) + color(symbol_color, '(') +


### PR DESCRIPTION
Newer libwayland versions emit "discarded" before messages whose proxy was destroyed before a reply was received.


```txt
[ 692165.621] {Default Queue} wl_surface#16.enter(wl_output#10)
[ 692165.626] {Default Queue} discarded wl_buffer#25.release()
[ 692175.536] {Display Queue} wl_display#1.delete_id(26)
```